### PR TITLE
Fix typedef

### DIFF
--- a/lib/ono.d.ts
+++ b/lib/ono.d.ts
@@ -51,5 +51,5 @@ declare module 'ono' {
     formatter(message: string, ...params: any[]): string;
   }
 
-  export default ono;
+  export = ono;
 }


### PR DESCRIPTION
Since `module.exports` is actually overwritten by the function returned by `create(Error)`, this is not an es6-module compatible scenario.
With this change,
```ts
import * as ono from 'ono'
throw ono(new Error('ono'))
```
and, perhaps more correctly
```ts
import ono = require('ono')
throw ono(new Error('ono'))
```
typecheck and generate correct code.

Before this change, only
```ts
import ono from 'ono'
throw ono(new Error('ono'))
```
and
```ts
import * as themodule from 'ono'
throw themodule.default(new Error('ono'))
```
would typecheck, both of which would throw at runtime by trying to call `ono.default()` or `ono.default.syntax()`, etc...